### PR TITLE
fixed add-apt-repository: command not found

### DIFF
--- a/extra/nginx/Dockerfile
+++ b/extra/nginx/Dockerfile
@@ -12,6 +12,6 @@ ARG CRT
 WORKDIR $HOME
 COPY . $HOME
 
-RUN apt-get update && apt-get -y install sudo apt-utils
+RUN apt-get update && apt-get -y install sudo apt-utils software-properties-common  libffi-dev
 RUN ./extra/provision.sh -m $MODE -c $TYPE -k $KEY -C $CRT -D $DOMAIN -e $EMAIL -s `pwd` --docker --multiple-servers --server-type nginx --hhvm-server hhvm
 CMD ["./extra/nginx/nginx_startup.sh"]

--- a/extra/provision.sh
+++ b/extra/provision.sh
@@ -292,7 +292,7 @@ fi
         if [[ "$MODE" == "dev" ]]; then
 
         sudo add-apt-repository ppa:deadsnakes/ppa
-         sudo apt update && sudo apt upgrade
+         sudo apt update && sudo apt upgrade -y
             sudo apt install -y python3.5
             package build-essential
             package libssl-dev


### PR DESCRIPTION
- add-apt-repository: command not found 
- fatal error: ffi.h: No such file or directory